### PR TITLE
Create a child scope within createDirective

### DIFF
--- a/src/angular-test-helpers.js
+++ b/src/angular-test-helpers.js
@@ -3,7 +3,7 @@
 
 /**
  * Creates a directive to poke at with tests.
- * 
+ *
  * @param {string} template - The template for the directive.
  * @returns {Object} jQuery/jqLite element
  *
@@ -15,8 +15,9 @@
 window.createDirective = function (template) {
   var elem;
   inject(function ($compile, $rootScope) {
-    elem = $compile(template)($rootScope);
-    $rootScope.$digest();
+    var scope = $rootScope.$new();
+    elem = $compile(template)(scope);
+    scope.$digest();
   });
   return elem;
 };


### PR DESCRIPTION
I experienced issues using your test helpers, where calling createDirective in a beforeEach block was causing some other directive's template to be requested. I assume this is due to the $rootScope.$digest() call, but I'm not sure. In any case, creating a child scope in createDirective should be safer?
